### PR TITLE
LIBITD-2487. Fix Jenkinsfile for Jenkins v2.440.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,7 +137,9 @@ pipeline {
       post {
         always {
           // Collect pycodestyle reports
-          recordIssues(tools: [pyLint(reportEncoding: 'UTF-8', name: 'ruff/pycodestyle check')], unstableTotalAll: 1)
+          recordIssues(tools: [pyLint(reportEncoding: 'UTF-8', name: 'ruff/pycodestyle check')],
+                       qualityGates: [[threshold: 1, type: 'TOTAL', criticality: 'UNSTABLE']]
+          )
 
           // Collect coverage reports
           publishHTML([


### PR DESCRIPTION
Updated the "recordIssues" directive in the "Jenkinsfile" to use the "qualityGates" parameter, instead of the obsolete "unstableTotalAll" parameter.

https://umd-dit.atlassian.net/browse/LIBITD-2487